### PR TITLE
Adds Package.swift to default open command group.

### DIFF
--- a/xcopen/main.swift
+++ b/xcopen/main.swift
@@ -44,7 +44,7 @@ struct Xcopen: ParsableCommand {
         case true:
             try Utility.searchAndOpen([".xcworkspace"], bg: openInBackground)
         case false:
-            try Utility.searchAndOpen([".xcodeproj", ".playground"], bg: openInBackground)
+            try Utility.searchAndOpen([".xcodeproj", ".playground", "Package.swift"], bg: openInBackground)
         }
     }
 


### PR DESCRIPTION
## Linked Issue: Closes #3 

I think it would be really cool if `xcopen` could open swift packages via the `Package.swift` file in Xcode by default along with `.xcodeproj` and `.playground`.

Tested this on my local swift package.